### PR TITLE
Portainer now shares networking with wireguard server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A private wireguard network stack (`PWN`) with Unbound DNS, PiHold ad blocking, 
 * 10.6.0.0/24 - IP Address range for peer connections to Wireguard server.
 * http://10.2.0.100/admin - Pi Hole Web UI
 * http://10.2.0.3:51821 - Easy Wireguard Web UI
-* http://10.2.0.4:9000 - Portainer Web UI
+* http://10.2.0.3:9000 - Portainer Web UI
 * 10.2.0.5:9001 - Portainer Agent
 
 ## References
@@ -92,7 +92,7 @@ Once you are connected to the wireguard server, you can access the Wireguard UI 
 ## Portainer Configuration (Using docker-compose-portainer)
 If you used the `docker-compose-portainer.yml` stack, the following instructions will help with accessing the portainer webpage. Follow these instructions after you have configured the your wireguard client connection to the pwn network.
 
-Go to `Portainer` (http://10.2.0.4:9000) and create a profile. After creating a profile, connect to the `Protainer Agent`. Connect to the the following endpoint: `10.2.0.5:9001`. Once connected, Portainer is ready to use.
+Go to `Portainer` (http://10.2.0.3:9000) and create a profile. After creating a profile, connect to the `Protainer Agent`. Connect to the the following endpoint: `10.2.0.5:9001`. Once connected, Portainer is ready to use.
 
 ## Additional Configurations
 You can add an Nginx reverse proxy to your private network by adding [this stack](https://github.com/rmayobre/scripted-selfhost/tree/main/docker/private-proxy-manager-stack) to your `pwn-network`. Update your `PiHole` local DNS records to point to the 10.2.0.0/24 ip address of your Nginx container. Then add the proxy to the nginx database (optionally you can add an SSL cert).

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -1,14 +1,14 @@
 version: "3.9"
 
 volumes:
+  portainer-data-volume:
+    name: portainer-data
   pihole-volume:
     name: pihole
   dnsmasq.d-volume:
     name: pihole-dnsmasq.d
   wireguard-volume:
     name: wireguard
-  portainer-data-volume:
-    name: portainer-data
 
 networks:
   private-network:
@@ -19,6 +19,7 @@ networks:
         - subnet: 10.2.0.0/24
 
 services:
+
   # Unbound DNS
   unbound:
     image: "mvance/unbound:latest"
@@ -30,6 +31,7 @@ services:
     networks:
       private-network:
         ipv4_address: 10.2.0.200
+
   # PiHold Ad Blocker
   # Pro tip: Use PiHole for local DNS Records to access your private webpages with domain names..
   pihole:
@@ -54,6 +56,7 @@ services:
     networks:
       private-network:
         ipv4_address: 10.2.0.100
+
   # easy-wg UI
   wireguard:
     depends_on: [unbound, pihole]
@@ -84,19 +87,24 @@ services:
       - net.ipv4.ip_forward=1
       - net.ipv4.conf.all.src_valid_mark=1
     networks:
+      portainer-network:
       private-network:
         ipv4_address: 10.2.0.3
-  #Portainer UI
+
+  # Portainer UI
+  # Portainer UI will share the network of Wireguard.
+  # Access Portainer UI via 10.2.0.3:9000
   portainer:
     image: portainer/portainer-ce
     container_name: portainer-ui
+    network_mode: service:wireguard
+    depends_on: [wireguard]
     restart: unless-stopped
     volumes:
       - portainer-data-volume:/data
-    networks:
-      private-network:
-        ipv4_address: 10.2.0.4 # Use this address to access webpage.
+      
   # Portainer Agent Service
+  # Connect to Portainer Agent via 10.2.0.5:9001
   agent:
     image: portainer/agent
     container_name: portainer-agent


### PR DESCRIPTION
Added Portainer UI and Wireguard server share networking now. This helps simplify setups that want a portainer UI for management.